### PR TITLE
Dev v1.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "992004863@qq.com",
     "url": "https://github.com/qiaolin-li/dubbo-desktop-manager"
   },
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "scripts": {
     "lint": "vue-cli-service lint",

--- a/src/common/i18n/lang/en-US.js
+++ b/src/common/i18n/lang/en-US.js
@@ -49,6 +49,8 @@ export default {
         baseSettings: {
             title: "Base Settings",
             language: "Language",
+            jvmArgs: "JVM Args",
+            jvmArgsTips: "Enter JVM Args, such as -Xmx512m"
         },
         apply: "Apply",
         invokerSettings : {

--- a/src/common/i18n/lang/en-US.js
+++ b/src/common/i18n/lang/en-US.js
@@ -80,6 +80,15 @@ export default {
         namespaceId: "namespaceId",
         username: "username",
         password: "password",
+        zookeeper: {
+            aclTips: "Enter the authentication information, for example, test:test"
+        },
+        nacos: {
+            groupName: 'ServiceGroupName',
+            groupNameTips: 'Enter the name of the service GROUP. The DEFAULT is DEFAULT GROUP',
+            group: 'ConfiguringGroupName',
+            groupTips: 'Please enter the configuration group name. The default is dubbo',
+        },
         validateMessage: {
             timeOutNotNull: "The timeout period cannot be empty",
             inputNumber: " Please enter the first group now",

--- a/src/common/i18n/lang/zh-CN.js
+++ b/src/common/i18n/lang/zh-CN.js
@@ -49,6 +49,8 @@ export default {
         baseSettings: {
             title: "基本设置",
             language: "语言",
+            jvmArgs: "JVM参数",
+            jvmArgsTips: "请输入JVM参数，如:-Xmx512m"
         },
         apply: "应用",
         invokerSettings : {

--- a/src/common/i18n/lang/zh-CN.js
+++ b/src/common/i18n/lang/zh-CN.js
@@ -80,6 +80,15 @@ export default {
         namespaceId: "命名空间ID",
         username: "用户名",
         password: "密码",
+        zookeeper: {
+            aclTips: "请输入认证信息, 例如：test:test"
+        },
+        nacos: {
+            groupName: '服务分组名称',
+            groupNameTips: '请输入服务分组名称，默认为 DEFAULT_GROUP',
+            group: '配置分组名称',
+            groupTips: '请输入配置分组名称，默认为 dubbo',
+        },
         validateMessage: {
             timeOutNotNull: "超时时间不能为空",
             inputNumber: "请输入数字",

--- a/src/main/dubbo/invoker/javaInvoker.js
+++ b/src/main/dubbo/invoker/javaInvoker.js
@@ -9,6 +9,7 @@ import i18n from '@/main/common/i18n'
 import common from "./common.js";
 import appConfig from "@/main/common/config/appConfig.js";
 
+
 let jarPath;
 if (process.env.NODE_ENV === 'development') {
     jarPath = path.join(__dirname, '../public/jar/java-invoker.jar');
@@ -71,13 +72,18 @@ function executeJar(outFile) {
             elapsedTime : 0
         });
     }
+
+    const jvmArgs = appConfig.getProperty("jvmArgs");
     const commandArgs = [
+        ...(jvmArgs ? [jvmArgs] : []),
         '-Dfile.encoding=utf-8',
         '-jar', jarPath,
         outFile
     ];
     const config = {
         // maxBuffer: 100 * 1024 * 1024 * 1024, // 1G
+        cwd: constant.USER_HOME_DIR,
+        shell: true
     }
 
     // eslint-disable-next-line no-unused-vars

--- a/src/main/registry/zookeeper/zkClientUtils.js
+++ b/src/main/registry/zookeeper/zkClientUtils.js
@@ -13,6 +13,9 @@ function createConncetion(registryConfig) {
     let zkClient = new Promise((resolve, reject) => {
         let zk = zookeeperClient.createClient(address, OPTIONS);
         zk.on("connected", function () {
+          if(registryConfig.scheme && registryConfig.auth){
+            zk.addAuthInfo(registryConfig.scheme, Buffer.from(registryConfig.auth));  
+          }
           resolve(zk);
         });
     
@@ -22,7 +25,6 @@ function createConncetion(registryConfig) {
     
         zk.connect();
       });
-
 
     return zkClient;
   }

--- a/src/main/repository/connectRepository.js
+++ b/src/main/repository/connectRepository.js
@@ -1,16 +1,10 @@
 import dbUtils from "@/main/common/utils/DBUtils.js";
 let dbOperator = dbUtils("zkConnectInfo");
 
-function ZkConnectInfo({_id, name ,type, address, namespaceId, username, password,sessionTimeout, createTime = new Date().getTime()}){
-    this._id = _id, 
-    this.name = name;
-    this.type = type;
-    this.address = address;
-    this.namespaceId = namespaceId;
-    this.username = username;
-    this.password = password;
-    this.sessionTimeout = sessionTimeout;
-    this.createTime = createTime;
+
+function ZkConnectInfo(obj){
+    Object.assign(this, obj)
+    this.createTime = new Date().getTime();
 }
 
 function save(zkConnectInfo){

--- a/src/renderer/views/connect/add/nacos-add.vue
+++ b/src/renderer/views/connect/add/nacos-add.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-form ref="form" :rules="rules" :model="form" label-width="100px">
+  <el-form ref="form" :rules="rules" :model="form" label-width="160px">
     <el-form-item :label="$t('connect.name')" prop="name">
       <el-input v-model="form.name"></el-input>
     </el-form-item>
@@ -11,6 +11,12 @@
     </el-form-item>
     <el-form-item :label="$t('connect.sessionTimeout')" prop="sessionTimeout">
       <el-input v-model="form.sessionTimeout"></el-input>
+    </el-form-item>
+    <el-form-item :label="$t('connect.nacos.groupName')" prop="groupName">
+      <el-input v-model="form.groupName"  :placeholder="$t('connect.nacos.groupNameTips')"  ></el-input>
+    </el-form-item>
+    <el-form-item :label="$t('connect.nacos.group')"  prop="group">
+      <el-input v-model="form.group" :placeholder="$t('connect.nacos.groupTips')" ></el-input>
     </el-form-item>
     <el-form-item>
       <el-button type="primary" @click="saveZkConnectInfo">{{$t('connect.save')}}</el-button>
@@ -32,6 +38,8 @@ export default {
         address: "http://127.0.0.1:8848",
         namespaceId: "",
         sessionTimeout: 5000,
+        groupName: '',
+        group: ''
       },
 
     };

--- a/src/renderer/views/connect/add/zookeeper-add.vue
+++ b/src/renderer/views/connect/add/zookeeper-add.vue
@@ -9,6 +9,14 @@
     <el-form-item :label="$t('connect.sessionTimeout')" prop="sessionTimeout">
       <el-input v-model="form.sessionTimeout"></el-input>
     </el-form-item>
+    <el-form-item label="ACL" prop="auth">
+      <el-input :placeholder="$t('connect.zookeeper.aclTips')"  v-model="form.auth" class="input-with-select">
+      <el-select v-model="form.scheme" slot="prepend" style="width:120px">
+        <el-option label="digest" value="digest"></el-option>
+        <el-option label="auth" value="auth"></el-option>
+      </el-select>
+    </el-input>
+    </el-form-item>
     <el-form-item>
       <el-button type="primary" @click="saveZkConnectInfo">{{$t('connect.save')}}</el-button>
     </el-form-item>
@@ -27,6 +35,7 @@ export default {
         name: "",
         address: "127.0.0.1:2181",
         sessionTimeout: 5000,
+        scheme: 'digest'
       },
 
     };
@@ -93,6 +102,7 @@ export default {
         this.form.name = "";
         this.form.address = "127.0.0.1:2181";
         this.form.sessionTimeout = 5000;
+        this.form.scheme = 'digest';
       }
     },
     async saveZkConnectInfo() {

--- a/src/renderer/views/connect/index.vue
+++ b/src/renderer/views/connect/index.vue
@@ -10,7 +10,7 @@
               <el-divider class="my-divider"></el-divider>
               <connectList ref="connectList" :mainPanel="mainPanel" @editConnect="openAddConnectDialog"></connectList>
 
-              <el-dialog :title="currentConnectId ? $t('connect.modifyConnect') : $t('connect.addConnect')" width="40%" :visible.sync="dialogVisible" :close-on-click-modal="false">
+              <el-dialog :title="currentConnectId ? $t('connect.modifyConnect') : $t('connect.addConnect')" width="70%" :visible.sync="dialogVisible" :close-on-click-modal="false">
                 <addConnect @saveSuccess="saveConnectSuccess" :id="currentConnectId" :key="addConnectKey" />
               </el-dialog>
             </div>

--- a/src/renderer/views/index.vue
+++ b/src/renderer/views/index.vue
@@ -202,7 +202,7 @@ export default {
 .menu-aside {
   height: 100%;
   align-items: center;
-  background-color: #ececec;
+  background-color: #f0f0f0;
 }
 
 .ddm-menu-list {

--- a/src/renderer/views/settings/index.vue
+++ b/src/renderer/views/settings/index.vue
@@ -21,6 +21,9 @@
         <el-button slot="append" icon="el-icon-search" @click="selectJavaHomePath"></el-button>
       </el-input>
     </div>
+    <br/>
+    {{$t('settings.baseSettings.jvmArgs')}}：
+    <el-input :placeholder="$t('settings.baseSettings.jvmArgsTips')" v-model="jvmArgs" style="width: 90%"  > </el-input>
     <el-divider content-position="left"></el-divider>
 
     <el-button @click="saveConfig">{{$t('settings.apply')}}</el-button>
@@ -40,6 +43,7 @@ export default {
       messages: [],
       invokerType: "telnet",
       javaHome: "",
+      jvmArgs: "",
       invokerTypes: [
         {
           code: "telnet",
@@ -57,6 +61,7 @@ export default {
     this.messages = i18n.messages;
     this.invokerType = await appConfig.getProperty("invokerType") || "telnet";
     this.javaHome = await appConfig.getProperty("javaHome");
+    this.jvmArgs = await appConfig.getProperty("jvmArgs");
   },
   methods: {
     async selectJavaHomePath() {
@@ -74,6 +79,7 @@ export default {
       appConfig.setProperty("systemLocale", this.selectMessage);
       appConfig.setProperty("invokerType", this.invokerType);
       appConfig.setProperty("javaHome", this.javaHome);
+      appConfig.setProperty("jvmArgs", this.jvmArgs);
     }
   }
 


### PR DESCRIPTION
1、支持zookeeper 认证
2、支持jdk17版本（需要使用者自己设置下面点jvm参数）
```java
 --add-opens java.management/java.lang.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-exports java.base/sun.security.action=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.base/sun.util.calendar=ALL-UNNAMED
```
![image](https://github.com/qiaolin-li/dubbo-desktop-manager/assets/32925394/bc7d5aeb-9dc7-4f02-bf8f-dbea99237a92)

3、修复nacos数据源若干个bug，支持设置服务分组和配置分组